### PR TITLE
feat: support for content dynamic body type

### DIFF
--- a/src/resources/contentApi.ts
+++ b/src/resources/contentApi.ts
@@ -86,7 +86,8 @@ export class ContentApi extends Resource {
                     ContentFormat.storage,
                     ContentFormat.view,
                     ContentFormat.styled_view,
-                    ContentFormat.export_view];
+                    ContentFormat.export_view,
+                    ContentFormat.dynamic];
 
                 for (let i = 0; i < views.length; i++) {
                     if (contentPage.body.hasOwnProperty(views[i]) && contentPage.body[views[i]].value) {
@@ -287,7 +288,7 @@ export class ContentApi extends Resource {
      */
     public async updateContent(id: string, props: UpdatePageProperties): Promise<Content> {
         const existingPage = await this.getContentById(id, [
-          "body","body.storage","body.view", "version","ancestors"
+          "body","body.storage","body.view","body.dynamic", "version","ancestors"
         ]);
         if (!existingPage) {
             throw 'Unable to find page with id ' + id;

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -60,7 +60,8 @@ export enum ContentFormat {
     storage = 'storage',
     styled_view = 'styled_view',
     view = 'view',
-    export_view = 'export_view'
+    export_view = 'export_view',
+    dynamic = 'dynamic'
 }
 
 /**
@@ -251,6 +252,7 @@ export type Content = {
         styled_view?: ContentView,
         storage?: ContentView,
         editor2?: ContentView,
+        dynamic?: ContentView,
         anonymous_export_view?: ContentView,
         _expandable?: any
     },


### PR DESCRIPTION
Adding support for `body.dynamic` type in content's body, which returns the body as JSON, as all other formats supported by Atlassian seem to be XHTML. 